### PR TITLE
* Fixed issue regarding double password hashing during user password …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 .env
 dist
+tsconfig.tsbuildinfo

--- a/src/controllers/AuthController.ts
+++ b/src/controllers/AuthController.ts
@@ -2,7 +2,7 @@ import type { Request, Response } from "express";
 import User from "../models/User";
 import Token from "../models/Token";
 import { generateAdminJWT, generateConfirmationToken, generateJWT, generatePasswordResetToken } from "../utils/jwt";
-import { comparePassword, hashPassword } from "../utils/auth";
+import { comparePassword } from "../utils/auth";
 import { RequestConflictError } from "../errors/conflict-error";
 import { NotFoundError } from "../errors/not-found";
 import { NotAuthorizedError } from "../errors/not-authorized";
@@ -96,10 +96,10 @@ export class AuthController {
         }
 
         // Set the password & Delete the token
-        user.password = await hashPassword(req.body.password);
+        user.password = req.body.password;
         user.passwordSet = true;
 
-        // Delete the token
+        // Delete the token (pre-save middleware handles hashing)
         await user.save(),
         await tokenRecord.deleteOne()
 
@@ -225,9 +225,9 @@ export class AuthController {
 
         // Set the password & Delete the token
         user.passwordSet = true // at this point user is certainly confirmed, so guard check to ensure his password is set.
-        user.password = await hashPassword(req.body.password);
+        user.password = req.body.password;
 
-        // Delete the token
+        // Delete the token (pre-save middleware handles hashing)
         await user.save(),
         await tokenRecord.deleteOne()
 

--- a/src/controllers/ProfileController.ts
+++ b/src/controllers/ProfileController.ts
@@ -1,6 +1,6 @@
 import type { Request, Response } from "express";
 import User, { UserInterface } from "../models/User";
-import { comparePassword, hashPassword } from "../utils/auth";
+import { comparePassword } from "../utils/auth";
 import { InternalServerError } from "../errors/server-error";
 import { NotAuthorizedError } from "../errors/not-authorized";
 import { RequestConflictError } from "../errors/conflict-error";
@@ -76,7 +76,7 @@ export class ProfileController {
                 throw new NotAuthorizedError("Contraseña Actual Incorrecta")
             }
 
-            user.password = await hashPassword(newPassword);
+            user.password = newPassword;
             await user.save();
 
             res.status(200).json({ message: "Contraseña Actualizada Exitosamente" })


### PR DESCRIPTION
Fixed password handling in both the `AuthController` and `ProfileController`. The main change is remove direct password hashing from controller logic, this because of the pre-save middleware created in the user model to handle password hashing automatically. 

Password handling updates:

* Controllers now assign plain passwords directly to `user.password` instead of using `hashPassword`, relying on pre-save middleware for hashing. (`src/controllers/AuthController.ts` [[1]](diffhunk://#diff-87c983f19bcefd8490e70379e7b4468828b0b2e7611cfa2e3c9aececeb47e585L99-R102) [[2]](diffhunk://#diff-87c983f19bcefd8490e70379e7b4468828b0b2e7611cfa2e3c9aececeb47e585L228-R230) `src/controllers/ProfileController.ts` [[3]](diffhunk://#diff-8e3c35e99cb6ef0e722ba321156665f54ed306cd3732c072007413ff9fa6c511L79-R79)
* Removed unused `hashPassword` import from both controllers, reflecting the change in password handling. (`src/controllers/AuthController.ts` [[1]](diffhunk://#diff-87c983f19bcefd8490e70379e7b4468828b0b2e7611cfa2e3c9aececeb47e585L5-R5) `src/controllers/ProfileController.ts` [[2]](diffhunk://#diff-8e3c35e99cb6ef0e722ba321156665f54ed306cd3732c072007413ff9fa6c511L3-R3)

Code clarity improvements:

* Added clarifying comments indicating that password hashing is handled by pre-save middleware, not in the controller. (`src/controllers/AuthController.ts` [[1]](diffhunk://#diff-87c983f19bcefd8490e70379e7b4468828b0b2e7611cfa2e3c9aececeb47e585L99-R102) [[2]](diffhunk://#diff-87c983f19bcefd8490e70379e7b4468828b0b2e7611cfa2e3c9aececeb47e585L228-R230)…updates.

Note: With the new User Model Updates, a .pre save middleware was added to automatically hash the password before saving it to DB. But i forgot to delete the password hashing expressions in ProfileController.ts (for updatePassword) and AuthController.ts (for resetPassword flow). This caused the password to be hashed twice, making it impossible for users to log in with their new passwords.